### PR TITLE
Prevent re-indexing of boolean series

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -133,8 +133,8 @@ for i, country in enumerate(selected_countries):
     col = cols[i % len(cols)]
 
     with col:
-        first_gdp = first_year[gdp_df['Country Code'] == country]['GDP'].iat[0] / 1000000000
-        last_gdp = last_year[gdp_df['Country Code'] == country]['GDP'].iat[0] / 1000000000
+        first_gdp = first_year[first_year['Country Code'] == country]['GDP'].iat[0] / 1000000000
+        last_gdp = last_year[last_year['Country Code'] == country]['GDP'].iat[0] / 1000000000
 
         if math.isnan(first_gdp):
             growth = 'n/a'


### PR DESCRIPTION
A mixing of dataframes for the purpose of masking creates the following indexing warning:
```
/Users/dmatthews/Documents/GitHub/gdp-dashboard-template/streamlit_app.py:136: UserWarning: Boolean Series key will be reindexed to match DataFrame index.
  first_gdp = first_year[gdp_df['Country Code'] == country]['GDP'].iat[0] / 1000000000
/Users/dmatthews/Documents/GitHub/gdp-dashboard-template/streamlit_app.py:137: UserWarning: Boolean Series key will be reindexed to match DataFrame index.
  last_gdp = last_year[gdp_df['Country Code'] == country]['GDP'].iat[0] / 1000000000
```

This PR updates the masking dataframe to be the same as the masked dataframe (which both came from the same, original dataframe).